### PR TITLE
Fix bug where SGD-X old key is name of another key's new key

### DIFF
--- a/sgd_x/utils.py
+++ b/sgd_x/utils.py
@@ -58,11 +58,11 @@ def replace_dict_keys_with_mapping(d: Dict[Any, Any],
                                    mapping: Dict[Any, Any]) -> None:
   """Replace dictionary keys in-place based on a mapping."""
   keys = list(d.keys())
-  for key in keys:
-    if key in mapping:
-      new_key = mapping[key]
-      # Remove old key and associate value with new key
-      d[new_key] = d.pop(key)
+  values = [d.pop(k) for k in keys]
+  for k, v in zip(keys, values):
+    if k in mapping:
+      k = mapping[k]
+    d[k] = v
 
 
 def replace_dict_value_with_mapping(d: Dict[Any, Any], key: Any,


### PR DESCRIPTION
Fix bug where SGD-X old key is name of another key's new key, as described in this issue: https://github.com/google-research-datasets/dstc8-schema-guided-dialogue/issues/57